### PR TITLE
feat: Implement chat screen with message history and markdown support

### DIFF
--- a/.idea/appInsightsSettings.xml
+++ b/.idea/appInsightsSettings.xml
@@ -1,8 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="AppInsightsSettings">
+    <option name="selectedTabId" value="Firebase Crashlytics" />
     <option name="tabSettings">
       <map>
+        <entry key="Android Vitals">
+          <value>
+            <InsightsFilterSettings>
+              <option name="failureTypes">
+                <list>
+                  <option value="ANR" />
+                </list>
+              </option>
+              <option name="signal" value="SIGNAL_UNSPECIFIED" />
+              <option name="timeIntervalDays" value="SEVEN_DAYS" />
+              <option name="visibilityType" value="ALL" />
+            </InsightsFilterSettings>
+          </value>
+        </entry>
         <entry key="Firebase Crashlytics">
           <value>
             <InsightsFilterSettings>
@@ -13,6 +28,12 @@
                   <option name="projectId" value="" />
                   <option name="projectNumber" value="" />
                 </ConnectionSetting>
+              </option>
+              <option name="failureTypes">
+                <list>
+                  <option value="FATAL" />
+                  <option value="ANR" />
+                </list>
               </option>
               <option name="signal" value="SIGNAL_UNSPECIFIED" />
               <option name="timeIntervalDays" value="THIRTY_DAYS" />

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -5,6 +5,12 @@
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
+      <SelectionState runConfigName="QuickChatCardPreview">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+      <SelectionState runConfigName="ChatHistoryDrawerPreview">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,6 +57,7 @@ android {
 
 dependencies {
 
+    val richtextVersion = "0.16.0"
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
@@ -66,10 +67,6 @@ dependencies {
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
     testImplementation(libs.junit)
-    androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation(libs.androidx.espresso.core)
-    androidTestImplementation(platform(libs.androidx.compose.bom))
-    androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
@@ -78,12 +75,15 @@ dependencies {
     implementation(libs.ktor.client.cio)   // CIO engine for Ktor client
     implementation(libs.ktor.client.json)   // JSON handling for Ktor client
     implementation(libs.ktor.client.serialization)  // Kotlinx Serialization for JSON
-    implementation("io.ktor:ktor-serialization-kotlinx-json:3.0.3") // Kotlinx serialization for JSON parsing
+    implementation(libs.ktor.serialization.kotlinx.json) // Kotlinx serialization for JSON parsing
 
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.coroutines.android)
 
     implementation (libs.ktor.client.logging)
     implementation(libs.ktor.client.content.negotiation)
-
+    implementation(libs.androidx.material.icons.extended)
+    implementation(libs.richtext.commonmark)
+    implementation("com.halilibo.compose-richtext:richtext-ui:${richtextVersion}")
+    implementation("com.halilibo.compose-richtext:richtext-commonmark:${richtextVersion}")
 }

--- a/app/src/main/java/com/app/chatbot/MainActivity.kt
+++ b/app/src/main/java/com/app/chatbot/MainActivity.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.app.chatbot.presentation.ChatScreen
+import com.app.chatbot.presentation.HomeScreen
 import com.app.chatbot.ui.theme.ChatbotTheme
 
 class MainActivity : ComponentActivity() {
@@ -23,7 +24,7 @@ class MainActivity : ComponentActivity() {
             ChatbotTheme {
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
                     Surface(modifier = Modifier.padding(innerPadding)) {
-                        ChatScreen()
+                        HomeScreen()
                     }
                 }
             }

--- a/app/src/main/java/com/app/chatbot/presentation/ChatScreen.kt
+++ b/app/src/main/java/com/app/chatbot/presentation/ChatScreen.kt
@@ -29,7 +29,6 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 @Composable
 fun ChatScreen(chatScreenViewModel: ChatScreenViewModel = viewModel()) {
     var query by remember { mutableStateOf("") }
-
     val responses = chatScreenViewModel.responses.value
     val isLoading = chatScreenViewModel.isLoading.value
     val errorMessage = chatScreenViewModel.errorMessage.value

--- a/app/src/main/java/com/app/chatbot/presentation/HomeScreen.kt
+++ b/app/src/main/java/com/app/chatbot/presentation/HomeScreen.kt
@@ -1,0 +1,237 @@
+package com.app.chatbot.presentation
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Segment
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.AddCircleOutline
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DrawerState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalDrawerSheet
+import androidx.compose.material3.ModalNavigationDrawer
+import androidx.compose.material3.NavigationDrawerItem
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberDrawerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.app.chatbot.presentation.components.ResponseCard
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun HomeScreen() {
+    val drawerState = rememberDrawerState(initialValue = androidx.compose.material3.DrawerValue.Closed)
+    val scope = rememberCoroutineScope()
+
+    ModalNavigationDrawer(
+        drawerState = drawerState,
+        drawerContent = {
+            AppDrawerContent(
+                drawerState = drawerState,
+                scope = scope,
+                onDrawerItemClick = { /* Handle item click */ }
+            )
+        }
+    ) {
+        Scaffold(
+            modifier = Modifier.fillMaxSize(),
+            topBar = {
+                TopBar(onNavigationIconClick = {
+                    scope.launch {
+                        drawerState.open()
+                    }
+                })
+            },
+            bottomBar = {
+                BottomBar()
+            }
+        ) { paddingValues ->
+            Chats(paddingValues = paddingValues)
+        }
+    }
+}
+
+@Composable
+fun AppDrawerContent(
+    drawerState: DrawerState,
+    scope: CoroutineScope,
+    onDrawerItemClick: () -> Unit
+) {
+    ModalDrawerSheet {
+        Text("History", modifier = Modifier.padding(16.dp))
+        NavigationDrawerItem(
+            label = { Text("Item 1") },
+            selected = false,
+            onClick = {
+                scope.launch {
+                    drawerState.close()
+                }
+                onDrawerItemClick()
+
+            }
+        )
+        NavigationDrawerItem(
+            label = { Text("Item 2") },
+            selected = false,
+            onClick = {
+                scope.launch {
+                    drawerState.close()
+                }
+                onDrawerItemClick()
+
+            }
+        )
+    }
+}
+
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TopBar(onNavigationIconClick: () -> Unit) {
+    TopAppBar(
+        colors = TopAppBarDefaults.topAppBarColors(
+            containerColor = MaterialTheme.colorScheme.background,
+        ),
+        title = { Text(text = "Chatbot") },
+        navigationIcon = {
+            IconButton(onClick = onNavigationIconClick) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.Segment,
+                    contentDescription = "List",
+                )
+            }
+        },
+        actions = {
+            IconButton(onClick = {}) {
+                Icon(
+                    imageVector = Icons.Filled.AddCircleOutline,
+                    contentDescription = "New Chat",
+                )
+            }
+            IconButton(onClick = {}) {
+                Icon(
+                    imageVector = Icons.Filled.MoreVert,
+                    contentDescription = "Options",
+                )
+            }
+        }
+    )
+}
+
+@Composable
+fun BottomBar(chatScreenViewModel: ChatScreenViewModel = viewModel()) {
+    var query by remember { mutableStateOf("") }
+
+    Column(
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        OutlinedTextField(
+            value = query,
+            onValueChange = { query = it },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp, vertical = 16.dp),
+            shape = RoundedCornerShape(24.dp),
+            placeholder = { Text("Type a message...") },
+            trailingIcon = {
+                IconButton(
+                    onClick = {
+                        chatScreenViewModel.sendQuery(query)
+                        query = ""
+                    },
+                    enabled = query.isNotEmpty()
+                ) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.Send,
+                        contentDescription = "Send"
+                    )
+                }
+            }
+        )
+    }
+}
+
+@Composable
+fun Chats(chatScreenViewModel: ChatScreenViewModel = viewModel(), paddingValues: PaddingValues) {
+
+    val responses = chatScreenViewModel.responses.value
+    val isLoading = chatScreenViewModel.isLoading.value
+    val errorMessage = chatScreenViewModel.errorMessage.value
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(paddingValues)
+    ) {
+        LazyColumn(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth(),
+            contentPadding = PaddingValues(16.dp),
+        ) {
+            items(responses) { response ->
+                ResponseCard(response)
+            }
+        }
+
+        // Loading and error indicators
+        if (isLoading) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                horizontalArrangement = Arrangement.Center
+            ) {
+                CircularProgressIndicator()
+            }
+        }
+
+        errorMessage?.let {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                horizontalArrangement = Arrangement.Center
+            ) {
+                Text(
+                    text = "Error: $it",
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun HomeScreenPreview() {
+    HomeScreen()
+}

--- a/app/src/main/java/com/app/chatbot/presentation/components/ChatCard.kt
+++ b/app/src/main/java/com/app/chatbot/presentation/components/ChatCard.kt
@@ -1,0 +1,47 @@
+package com.app.chatbot.presentation.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun QuickChatCard(query: String){
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .fillMaxHeight(.07f)
+            .padding(8.dp)
+            .clickable(onClick = {}),
+
+    ){
+        Box(
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = query,
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.bodyLarge
+            )
+        }
+    }
+}
+
+
+@Preview(showBackground = true)
+@Composable
+fun QuickChatCardPreview(){
+    QuickChatCard(query = "Hello World")
+}

--- a/app/src/main/java/com/app/chatbot/presentation/components/ChatHistoryDrawer.kt
+++ b/app/src/main/java/com/app/chatbot/presentation/components/ChatHistoryDrawer.kt
@@ -1,0 +1,97 @@
+package com.app.chatbot.presentation.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Segment
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ModalDrawerSheet
+import androidx.compose.material3.ModalNavigationDrawer
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberDrawerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import kotlinx.coroutines.launch
+
+
+@Composable
+fun ChatHistoryDrawer(modifier: Modifier){
+    val drawerState = rememberDrawerState(
+        initialValue = DrawerValue.Closed
+    )
+    val scope = rememberCoroutineScope()
+
+    ModalNavigationDrawer(
+        drawerState = drawerState,
+        drawerContent = {
+            ModalDrawerSheet {
+                DrawerContent()
+            }
+        }
+    ) {
+        Scaffold (
+            topBar = {
+                NavTopBar(
+                    onOpenDrawer = {
+                        scope.launch {
+                            drawerState.apply {
+                                if (isClosed) open() else close()
+                            }
+                        }
+                    }
+                )
+            }
+            ) {paddingValues ->
+            ScreenContent(modifier = Modifier.padding(paddingValues))
+        }
+    }
+}
+
+@Composable
+fun DrawerContent(modifier: Modifier = Modifier) {
+
+}
+
+
+@Composable
+fun ScreenContent(modifier: Modifier = Modifier) {
+
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NavTopBar(
+    onOpenDrawer: () -> Unit
+) {
+    TopAppBar(
+        navigationIcon = {
+            IconButton(onClick = { /*TODO*/ }) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.Segment,
+                    contentDescription = "Menu",
+                    modifier = Modifier.clickable {
+                        onOpenDrawer()
+                    }
+                )
+            }
+        },
+        title = {
+            Text("History")
+        }
+    )
+}
+
+
+@Preview(showBackground = true)
+@Composable
+fun ChatHistoryDrawerPreview(){
+    ChatHistoryDrawer(modifier = Modifier)
+}

--- a/app/src/main/java/com/app/chatbot/presentation/components/ResponseCard.kt
+++ b/app/src/main/java/com/app/chatbot/presentation/components/ResponseCard.kt
@@ -1,0 +1,89 @@
+package com.app.chatbot.presentation.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.halilibo.richtext.markdown.Markdown
+import com.halilibo.richtext.markdown.MarkdownParseOptions
+import com.halilibo.richtext.ui.RichText
+
+
+@Composable
+fun UserQueryCard(text: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        horizontalArrangement = Arrangement.End
+    ) {
+        Text(
+            text = text,
+            modifier = Modifier
+                .padding(8.dp)
+                .fillMaxWidth(0.8f),
+            style = MaterialTheme.typography.bodyMedium
+        )
+    }
+}
+
+@Composable
+fun ResponseCard(text: String){
+    Card(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(start = 0.dp, end = 32.dp, top = 8.dp, bottom = 2.dp),
+
+        elevation = CardDefaults.cardElevation(8.dp),
+        colors = CardDefaults.cardColors(MaterialTheme.colorScheme.background)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(8.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+
+        ) {
+            MarkdownText(text)
+        }
+    }
+}
+
+@Composable
+fun MarkdownText(text: String){
+    val markdownParseOptions = MarkdownParseOptions(
+        autolink = false
+    )
+    RichText(
+        modifier = Modifier
+            .padding(start = 8.dp, end = 8.dp, top = 2.dp, bottom = 2.dp),
+
+
+
+    ){
+        Markdown(
+            text,
+            markdownParseOptions = markdownParseOptions
+            )
+    }
+}
+
+
+@Preview
+@Composable
+fun ResponseCardPreview(){
+    ResponseCard(text = "Hello World")
+
+}

--- a/app/src/main/java/com/app/chatbot/presentation/model/ChatItem.kt
+++ b/app/src/main/java/com/app/chatbot/presentation/model/ChatItem.kt
@@ -1,0 +1,6 @@
+package com.app.chatbot.presentation.model
+
+data class ChatItem(
+    val text: String,
+    val isUser: Boolean
+)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,24 +5,25 @@ coreKtx = "1.15.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
-kotlinxSerializationJson = "1.8.0"
-kotlinxSerialization ="1.6"
 ktorClientCio = "3.0.3"
 ktorClientContentNegotiation = "3.0.3"
 ktorClientCore = "3.0.3"
 ktorClientJson = "3.0.3"
 ktorClientLogging = "3.0.3"
 ktorClientSerialization = "3.0.3"
-langchain4j = "1.0.0-alpha1"
-langchain4jMistralAi = "1.0.0-alpha1"
+ktorSerializationKotlinxJson = "3.0.3"
 lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.9.3"
 composeBom = "2024.04.01"
 coroutines = "1.9.0"
 lifecycleViewmodelCompose = "2.8.7"
+markdown = "0.3.15"
+materialIconsExtended = "1.7.6"
+richtextCommonmark = "0.16.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version.ref = "materialIconsExtended" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
@@ -36,7 +37,6 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
-kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktorClientCio" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktorClientContentNegotiation" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktorClientCore" }
@@ -46,8 +46,10 @@ ktor-client-serialization = { module = "io.ktor:ktor-client-serialization", vers
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycleViewmodelCompose" }
-langchain4j = { module = "dev.langchain4j:langchain4j", version.ref = "langchain4j" }
-langchain4j-mistral-ai = { module = "dev.langchain4j:langchain4j-mistral-ai", version.ref = "langchain4jMistralAi" }
+ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktorSerializationKotlinxJson" }
+markdown = { module = "org.jetbrains:markdown", version.ref = "markdown" }
+richtext-commonmark = { module = "com.halilibo.compose-richtext:richtext-commonmark", version.ref = "richtextCommonmark" }
+
 
 
 [plugins]


### PR DESCRIPTION
This commit introduces the following changes:

- Adds ChatItem data class to represent chat messages.
- Creates QuickChatCard composable for displaying quick chat options.
- Updates build.gradle.kts to include necessary dependencies like richtext, material icons, and kotlinx serialization.
- Adds HomeScreen composable as the main screen which handles top and bottom bar
- Implements AppDrawerContent for history display
- Introduces a ChatHistoryDrawer composable for managing chat history.
- Creates a ResponseCard composable for displaying chat messages with markdown support.
- Updates MainActivity to use the HomeScreen composable.
- Implements a BottomBar composable for handling user input and sending messages.
- Implements logic for displaying loading indicators and error messages in the chat.
- Updates ChatScreen to use the new composables and layout.
- Adds a MarkdownText composable to handle text formatting
- Refactors ChatScreen to use a state managed by ChatScreenViewModel