### PR TITLE
feat: Add forget password functionality and update UI

### DIFF
--- a/app/src/main/java/com/app/chatbot/Navigation.kt
+++ b/app/src/main/java/com/app/chatbot/Navigation.kt
@@ -5,6 +5,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.app.chatbot.presentation.HomeScreen
+import com.app.chatbot.presentation.auth.signin.ForgetPassword
 import com.app.chatbot.presentation.auth.signin.SignInScreen
 import com.app.chatbot.presentation.auth.signup.SignUpScreen
 import com.app.chatbot.repository.auth.GoogleAuthClient
@@ -22,6 +23,9 @@ fun MainNavigation(googleAuthClient: GoogleAuthClient){
         }
         composable(route = Screen.HomeScreen.route){
             HomeScreen(navController = navController, googleAuthClient = googleAuthClient)
+        }
+        composable(route = Screen.ForgetPassword.route){
+            ForgetPassword(navController = navController)
         }
 
     }

--- a/app/src/main/java/com/app/chatbot/Screen.kt
+++ b/app/src/main/java/com/app/chatbot/Screen.kt
@@ -1,11 +1,9 @@
 package com.app.chatbot
 
-import kotlinx.serialization.Serializable
-
-
 sealed class Screen(val route: String) {
     object HomeScreen : Screen("home_screen")
     object SignInScreen : Screen("sign_in_screen")
     object SignUpScreen : Screen("sign_up_screen")
+    object ForgetPassword: Screen("forget_password_screen")
 
 }

--- a/app/src/main/java/com/app/chatbot/presentation/HomeScreen.kt
+++ b/app/src/main/java/com/app/chatbot/presentation/HomeScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Segment
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.AddCircleOutline
+import androidx.compose.material3.Card
 import androidx.compose.material3.DrawerState
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -50,6 +51,7 @@ import androidx.navigation.NavController
 import com.app.chatbot.Screen
 import com.app.chatbot.presentation.auth.signin.clearSession
 import com.app.chatbot.presentation.components.ResponseCard
+import com.app.chatbot.presentation.model.ChatItem
 import com.app.chatbot.repository.auth.GoogleAuthClient
 import com.app.chatbot.repository.db.ChatDatabase
 import com.app.chatbot.repository.db.ChatMessage
@@ -123,21 +125,31 @@ fun AppDrawerContent(
         Column(
             modifier = Modifier.fillMaxSize()
         ) {
-            Text("History", modifier = Modifier.padding(16.dp))
+            Text(
+                "History", modifier = Modifier.padding(16.dp),
+                style = MaterialTheme.typography.bodyLarge
+            )
 
             LazyColumn(
                 modifier = Modifier.weight(1f)
             ) {
                 items(chatHistory) { message ->
-                    Text(
-                        text = message.message,
-                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
-                    )
+                  Card(
+                      modifier = Modifier.padding(8.dp)
+                  ) {
+                      Text(
+                          text = message.message,
+                          modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                      )
+                  }
                 }
             }
 
             NavigationDrawerItem(
-                label = { Text("Logout") },
+                label = { Text(
+                    "Logout",
+                    style = MaterialTheme.typography.titleMedium
+                ) },
                 selected = false,
                 onClick = {
                     scope.launch {
@@ -208,7 +220,8 @@ fun BottomBar(chatScreenViewModel: ChatScreenViewModel = viewModel()) {
             trailingIcon = {
                 IconButton(
                     onClick = {
-                        if (query.isNotEmpty()) {
+                        if (
+                            query.isNotEmpty()) {
                             chatScreenViewModel.sendQuery(query)
                             query = ""
                             keyboardController?.hide()
@@ -255,7 +268,6 @@ fun Chats(
             items(responses.value) { response ->
                 ResponseCard(response)
 
-                // Combine query and response as a single string and save it
                 LaunchedEffect(response) {
                     val combinedMessage = "Query: ${response.query}\nResponse: ${response.response}"
                     chatHistoryViewModel.saveMessage(

--- a/app/src/main/java/com/app/chatbot/presentation/auth/authScreen.kt
+++ b/app/src/main/java/com/app/chatbot/presentation/auth/authScreen.kt
@@ -1,4 +1,0 @@
-package com.app.chatbot.presentation.auth
-
-class authScreen {
-}

--- a/app/src/main/java/com/app/chatbot/presentation/auth/signin/ForgetPassword.kt
+++ b/app/src/main/java/com/app/chatbot/presentation/auth/signin/ForgetPassword.kt
@@ -1,0 +1,64 @@
+package com.app.chatbot.presentation.auth.signin
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Button
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.TextRange
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import com.app.chatbot.Screen
+import com.app.chatbot.repository.auth.AuthenticationManager
+
+@Composable
+fun ForgetPassword(
+    navController: NavController
+){
+    var email by remember { mutableStateOf("") }
+    val context = LocalContext.current
+    val authenticationManager = remember { AuthenticationManager(context) }
+
+
+ Surface {
+     Column(
+         modifier = Modifier.fillMaxSize(),
+         verticalArrangement = Arrangement.Center,
+         horizontalAlignment = Alignment.CenterHorizontally
+     ) {
+         TextField(
+             value = email,
+             onValueChange = { email = it },
+             label = { Text("Email") },
+             placeholder = { Text("Enter your email") },
+             singleLine = true,
+             modifier = Modifier.fillMaxWidth()
+         )
+         Button(
+             onClick = {
+                 authenticationManager.forgetPassword(email)
+                 navController.navigate(Screen.SignInScreen.route)
+             },
+             modifier = Modifier.fillMaxWidth()
+
+         ){
+             Text(
+                 text = "ResetPassword"
+             )
+         }
+     }
+ }
+
+
+}

--- a/app/src/main/java/com/app/chatbot/presentation/auth/signin/SignInScreen.kt
+++ b/app/src/main/java/com/app/chatbot/presentation/auth/signin/SignInScreen.kt
@@ -47,10 +47,8 @@ fun SignInScreen(
 
     val sharedPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
 
-    // State to track navigation to HomeScreen
     var hasNavigatedToHome by remember { mutableStateOf(false) }
 
-    // Observe `isLoggedIn` using LaunchedEffect
     val isLoggedIn = remember { mutableStateOf(sharedPreferences.getBoolean(KEY_IS_LOGGED_IN, false)) }
 
     LaunchedEffect(isLoggedIn.value) {
@@ -104,7 +102,7 @@ fun SignInScreen(
                     Spacer(modifier = Modifier.weight(1f))
                     Text(
                         text = "Forgot Password?",
-                        modifier = Modifier.clickable { /* Navigate to forgot password screen */ }
+                        modifier = Modifier.clickable { navController.navigate(Screen.ForgetPassword.route)}
                     )
                 }
                 Spacer(modifier = Modifier.size(16.dp))
@@ -146,7 +144,7 @@ fun SignInScreen(
                         modifier = Modifier.clickable {
                             navController.navigate(Screen.SignUpScreen.route)
                         },
-                        color = Color.Blue
+                        color = Color(0xFF00B2FF)
                     )
                 }
                 Spacer(modifier = Modifier.size(16.dp))

--- a/app/src/main/java/com/app/chatbot/presentation/auth/signup/SignUpScreen.kt
+++ b/app/src/main/java/com/app/chatbot/presentation/auth/signup/SignUpScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import com.app.chatbot.Screen
 import com.app.chatbot.repository.auth.AuthResponse
 import com.app.chatbot.repository.auth.AuthenticationManager
 import kotlinx.coroutines.flow.launchIn
@@ -140,6 +141,7 @@ fun SignUpScreen(
                                     Log.d("LOGGED_IN", "Login callback triggered $response")
                                 }
                             }.launchIn(coroutineScope)
+                        navController.navigate(Screen.SignInScreen.route)
                     },
                     modifier = Modifier.fillMaxWidth(),
                     enabled = password.isNotEmpty() && confirmPassword.isNotEmpty() && isPasswordMatch

--- a/app/src/main/java/com/app/chatbot/repository/auth/AuthenticationManager.kt
+++ b/app/src/main/java/com/app/chatbot/repository/auth/AuthenticationManager.kt
@@ -44,70 +44,11 @@ class AuthenticationManager(val context: Context) {
         awaitClose()
 
     }
-/*
-    private fun createNonce(): String{
-        val rawNonce = UUID.randomUUID().toString()
-        val bytes = rawNonce.toByteArray()
-        val md = MessageDigest.getInstance("SHA-256")
-        val digest = md.digest(bytes)
 
-        return digest.fold("") { str, it ->
-            str + "%02x".format(it)
-        }
+    fun forgetPassword(email: String): Flow<AuthResponse> = callbackFlow {
+        auth.sendPasswordResetEmail(email)
+
     }
-   fun signInWithGoogle(): Flow<AuthResponse> = callbackFlow {
-        val googleIdOptions = GetGoogleIdOption.Builder()
-            .setFilterByAuthorizedAccounts(false)
-            .setServerClientId(context.getString(R.string.web_client_id))
-            .setAutoSelectEnabled(false)
-            .setNonce(createNonce())
-            .build()
-
-        val request = GetCredentialRequest.Builder()
-            .addCredentialOption(googleIdOptions)
-            .build()
-
-        try {
-            val credentialManager =  androidx.credentials.CredentialManager.create(context)
-
-            val result = credentialManager.getCredential(
-                context = context,
-                request = request
-            )
-
-            val credential = result.credential
-            if(credential is CustomCredential) {
-                if (credential.type == GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL) {
-                    try {
-                        val googleIdTokenCredential = GoogleIdTokenCredential
-                            .createFrom(credential.data)
-                        val firebaseCredential = GoogleAuthProvider.getCredential(
-                            googleIdTokenCredential.idToken,
-                            null
-                        )
-
-                        auth.signInWithCredential(firebaseCredential)
-                            .addOnCompleteListener{
-                                if (it.isSuccessful) {
-                                    trySend(AuthResponse.Success)
-                                } else {
-                                    trySend(AuthResponse.Error(it.exception?.message ?: "Unknown error"))
-                                }
-                            }
-                    } catch (e: GoogleIdTokenParsingException) {
-                        trySend(AuthResponse.Error(e.message ?: "Unknown error"))
-                    }
-
-                }
-            }
-
-
-        } catch(e: Exception) {
-            trySend(AuthResponse.Error(e.message ?: "Unknown error"))
-        }
-        awaitClose()
-
-    } */
  }
 
 


### PR DESCRIPTION
This commit introduces the following changes:

-   Removes the unused `authScreen` file.
-   Updates `HomeScreen` to display history messages in a `Card`.
-   Adds styling to `History` and `Logout` labels in `HomeScreen`.
-   Adds navigation for `ForgetPassword` screen.
-   Implements `ForgetPassword` screen with email input and reset functionality.
-   Refactors the `AuthenticationManager` to support the forget password flow.
-   Adds `ForgetPassword` route to the `Screen` sealed class.
-   Adds a click action to `Forget Password?` text on the `SignInScreen` to navigate to `ForgetPassword` screen.
-   Updates `SignUpScreen` to redirect to `SignInScreen` after successful signup.
-   Changes the color of the "Already have an account?" text to light blue in the `SignInScreen`.